### PR TITLE
Add chat history & security pages

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -54,16 +54,6 @@ modelChat = genai.GenerativeModel(
                         },
                         system_instruction=personaSystemInstruction
                     )
-modelSuggest = genai.GenerativeModel(
-                    model_name="gemini-1.5-flash",
-                    generation_config= {
-                            "temperature": 1.4,
-                            "top_p": 0.95,
-                            "top_k": 40,
-                            "max_output_tokens": 8192,
-                        }
-                )
-suggest = modelSuggest.start_chat(history=[])
 
 def getFirstHistory():
     return [{
@@ -77,32 +67,38 @@ def getFirstHistory():
 def processChatRequest(username,query,historyFileName):
     outputResponse = {"chat" : "", "suggestions" : ""}
     oldHistoryChat = {}
-    if query != "" : 
+    if query != "" :
         fileContent = read_file_from_gcs("personas-bucket-test",f"chats/{username}/{historyFileName}")
         if (fileContent == {} or json.loads(fileContent)["chat-history"] == {}):
             oldHistoryChat = getFirstHistory()
-        else :    
+        else :
             record = json.loads(fileContent)
             oldHistoryChat = record["chat-history"]
-        
+
         print(f"query {query} loaded history : {oldHistoryChat}")
         chat = modelChat.start_chat(history=oldHistoryChat)
-        response = chat.send_message(query) 
-        suggestionQuery = response.text
-        outputResponse["chat"] = suggestionQuery
-        oldHistoryChat.append({"role" : "user","parts" : [query]})
-        oldHistoryChat.append({"role" : "assistant","parts" : [suggestionQuery]})
+        suggestionsInstruction = read_file_from_gcs("personas-bucket-test","avatars/avery-suggestions-prompt.txt")
+        suggestionsInstruction = suggestionsInstruction.replace("${lastMessage}", query)
+        combined_query = f"{query}\n\n{suggestionsInstruction}\nReturn your response first. After that, start a new line with 'SUGGESTIONS:' followed by each suggestion on its own line."
+        response = chat.send_message(combined_query)
+        full_text = response.text
+        if "SUGGESTIONS:" in full_text:
+            chat_text, sugg_text = full_text.split("SUGGESTIONS:", 1)
+            outputResponse["chat"] = chat_text.strip()
+            suggestions = [s.strip("- \n") for s in sugg_text.strip().splitlines() if s.strip()]
+            outputResponse["suggestions"] = "\n".join(suggestions)
+        else:
+            outputResponse["chat"] = full_text
+            outputResponse["suggestions"] = ""
 
-    
-    else : 
-        suggestionQuery = "Hey! 👋 I'm Avery. I'm a 23-year-old digital marketing professional with deep insights into Gen Z consumer behavior and hybrid shopping trends. Ask me anything or click on my profile picture to learn more about me!"
-    ## getting suggestions
-    suggestionsInstruction = read_file_from_gcs("personas-bucket-test","avatars/avery-suggestions-prompt.txt")
-    suggestionsInstruction = suggestionsInstruction.replace("${lastMessage}",suggestionQuery)
-    suggestResponse = suggest.send_message(suggestionsInstruction) 
-    outputResponse["suggestions"] = suggestResponse.text
-    
-    historyRecord = {"chat-history" : oldHistoryChat,"suggestion-history" : suggestResponse.text}
+        oldHistoryChat.append({"role" : "user","parts" : [query]})
+        oldHistoryChat.append({"role" : "assistant","parts" : [outputResponse["chat"]]})
+
+    else :
+        outputResponse["chat"] = FIRST_MSG
+        outputResponse["suggestions"] = ""
+
+    historyRecord = {"chat-history" : oldHistoryChat,"suggestion-history" : outputResponse["suggestions"]}
     upload_file_to_gcs("personas-bucket-test",f"chats/{username}/{historyFileName}",historyRecord)
     return outputResponse
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,6 +3,8 @@ import { Routes, Route, useNavigate, Navigate } from 'react-router-dom'
 import { Suspense, lazy } from 'react'
 import Dashboard from './pages/Dashboard'
 import AppHome from './pages/AppHome'
+import Security from './pages/Security'
+import ChatHistory from './pages/ChatHistory'
 const Landing = lazy(() => import('./pages/Landing'))
 import { Toaster } from 'react-hot-toast'
 
@@ -36,6 +38,8 @@ function App() {
         } />
         <Route path="/app" element={<AppHome />} />
         <Route path="/dashboard" element={<Dashboard />} />
+        <Route path="/security" element={<Security />} />
+        <Route path="/history" element={<ChatHistory />} />
         <Route path="*" element={<Navigate to="/" replace />} />
       </Routes>
       <Toaster position="top-right" />

--- a/src/lib/gemini/index.ts
+++ b/src/lib/gemini/index.ts
@@ -6,7 +6,7 @@ const SECRET_KEY = 'Y7mA3rftGFrSSed87dXfK9Zq1VtPgUcY8WrQjN6e2Hxs';
 const BASIC_AUTH = 'Basic ' + btoa('srk:test');
 
 export async function sendToCloudFunction(
-  type: 'chat' | 'image-analysis' | 'generate-image',
+  type: 'chat' | 'image-analysis' | 'generate-image' | 'history' | 'historyChatContent',
   payload: object
 ): Promise<any> {
   try {
@@ -103,4 +103,12 @@ export class GeminiChat {
       image,
     };
   }
+}
+
+export async function getChatHistory() {
+  return sendToCloudFunction('history', {});
+}
+
+export async function getChatHistoryContent(historyFileName: string) {
+  return sendToCloudFunction('historyChatContent', { historyFileName });
 }

--- a/src/pages/ChatHistory.tsx
+++ b/src/pages/ChatHistory.tsx
@@ -1,0 +1,42 @@
+import { useEffect, useState } from 'react'
+import { getChatHistory, getChatHistoryContent } from '../lib/gemini'
+
+export default function ChatHistory() {
+  const [files, setFiles] = useState<string[]>([])
+  const [selected, setSelected] = useState<string | null>(null)
+  const [content, setContent] = useState<any>(null)
+
+  useEffect(() => {
+    getChatHistory()
+      .then(res => setFiles(res.chats || []))
+      .catch(err => console.error(err))
+  }, [])
+
+  const loadContent = async (file: string) => {
+    setSelected(file)
+    try {
+      const res = await getChatHistoryContent(file)
+      setContent(res)
+    } catch (err) {
+      console.error(err)
+    }
+  }
+
+  return (
+    <div className="min-h-screen bg-white p-6">
+      <h1 className="text-2xl font-bold mb-4">Chat History</h1>
+      <ul className="space-y-2">
+        {files.map(f => (
+          <li key={f}>
+            <button className="text-blue-600" onClick={() => loadContent(f)}>{f}</button>
+          </li>
+        ))}
+      </ul>
+      {content && (
+        <pre className="mt-4 bg-gray-100 p-4 rounded overflow-auto text-sm">
+          {JSON.stringify(content, null, 2)}
+        </pre>
+      )}
+    </div>
+  )
+}

--- a/src/pages/Security.tsx
+++ b/src/pages/Security.tsx
@@ -1,0 +1,13 @@
+import React from 'react'
+
+export default function Security() {
+  return (
+    <div className="min-h-screen bg-white p-6">
+      <h1 className="text-2xl font-bold mb-4">Security</h1>
+      <p className="text-gray-700">
+        Requests to the backend are protected by basic authentication and a secret API key as
+        defined in <code>backend/main.py</code>.
+      </p>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- make only one call to Gemini by generating suggestions in the same message
- expose history endpoints to the frontend helpers
- add security and history pages
- wire new pages into the router

## Testing
- `npm run lint` *(fails: 66 errors)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_685a7cd40d98832fbc3cb9c227b664fe